### PR TITLE
Fix warnings and potential linking errors on FreeBSD and DragonFly

### DIFF
--- a/src/hrtf/portable_endian.h
+++ b/src/hrtf/portable_endian.h
@@ -41,22 +41,9 @@
 #	define __LITTLE_ENDIAN LITTLE_ENDIAN
 #	define __PDP_ENDIAN    PDP_ENDIAN
 
-#elif defined(__NetBSD__) || defined(__OpenBSD__)
+#elif defined(__DragonFly__) || defined(__FreeBSD__) || defined defined(__NetBSD__) || defined(__OpenBSD__)
 
 #	include <sys/endian.h>
-
-#elif defined(__FreeBSD__) || defined(__DragonFly__)
- 
-#	include <sys/endian.h>
-
-#	define be16toh(x) betoh16(x)
-#	define le16toh(x) letoh16(x)
-
-#	define be32toh(x) betoh32(x)
-#	define le32toh(x) letoh32(x)
-
-#	define be64toh(x) betoh64(x)
-#	define le64toh(x) letoh64(x)
 
 #elif defined(__WINDOWS__)
 


### PR DESCRIPTION
The BSDs have been rather unified with regards to these naming conventions within the past 9 years. Maintainer of the FreeBSD port here (and by extension, the DragonFly port) here. Related to #211.

[90% 40/43] /usr/local/libexec/ccache/cc  -I/wrkdirs/usr/ports/audio/libmysofa/work/.build/src -I/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf -O2 -pipe  -fstack-protector-strong -fno-strict-aliasing -Wall -O2 -pipe  -fstack-protector-strong -fno-strict-aliasing  -DNDEBUG -std=gnu99 -fPIC -MD -MT src/CMakeFiles/mysofa-static.dir/hrtf/reader.c.o -MF src/CMakeFiles/mysofa-static.dir/hrtf/reader.c.o.d -o src/CMakeFiles/mysofa-static.dir/hrtf/reader.c.o -c /wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c
In file included from /wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c:18:
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/portable_endian.h:52:10: warning: 'be16toh' macro redefined [-Wmacro-redefined]
#       define be16toh(x) betoh16(x)
               ^
/usr/include/sys/endian.h:77:9: note: previous definition is here
#define be16toh(x)      bswap16((x))
        ^
In file included from /wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c:18:
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/portable_endian.h:53:10: warning: 'le16toh' macro redefined [-Wmacro-redefined]
#       define le16toh(x) letoh16(x)
               ^
/usr/include/sys/endian.h:80:9: note: previous definition is here
#define le16toh(x)      ((uint16_t)(x))
        ^
In file included from /wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c:18:
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/portable_endian.h:55:10: warning: 'be32toh' macro redefined [-Wmacro-redefined]
#       define be32toh(x) betoh32(x)
               ^
/usr/include/sys/endian.h:78:9: note: previous definition is here
#define be32toh(x)      bswap32((x))
        ^
In file included from /wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c:18:
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/portable_endian.h:56:10: warning: 'le32toh' macro redefined [-Wmacro-redefined]
#       define le32toh(x) letoh32(x)
               ^
/usr/include/sys/endian.h:81:9: note: previous definition is here
#define le32toh(x)      ((uint32_t)(x))
        ^
In file included from /wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c:18:
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/portable_endian.h:58:10: warning: 'be64toh' macro redefined [-Wmacro-redefined]
#       define be64toh(x) betoh64(x)
               ^
/usr/include/sys/endian.h:79:9: note: previous definition is here
#define be64toh(x)      bswap64((x))
        ^
In file included from /wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c:18:
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/portable_endian.h:59:10: warning: 'le64toh' macro redefined [-Wmacro-redefined]
#       define le64toh(x) letoh64(x)
               ^
/usr/include/sys/endian.h:82:9: note: previous definition is here
#define le64toh(x)      ((uint64_t)(x))
        ^
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c:183:11: warning: implicit declaration of function 'letoh64' is invalid in C99 [-Wimplicit-function-declaration]
    u.i = le64toh(*p2++);
          ^
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/portable_endian.h:59:21: note: expanded from macro 'le64toh'
#       define le64toh(x) letoh64(x)
                          ^
7 warnings generated.
[ 93% 41/43] /usr/local/libexec/ccache/cc -Dmysofa_shared_EXPORTS -I/wrkdirs/usr/ports/audio/libmysofa/work/.build/src -I/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf -O2 -pipe  -fstack-protector-strong -fno-strict-aliasing -Wall -O2 -pipe  -fstack-protector-strong -fno-strict-aliasing  -DNDEBUG -std=gnu99 -fPIC -fvisibility=hidden -MD -MT src/CMakeFiles/mysofa-shared.dir/hrtf/reader.c.o -MF src/CMakeFiles/mysofa-shared.dir/hrtf/reader.c.o.d -o src/CMakeFiles/mysofa-shared.dir/hrtf/reader.c.o -c /wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c
In file included from /wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c:18:
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/portable_endian.h:52:10: warning: 'be16toh' macro redefined [-Wmacro-redefined]
#       define be16toh(x) betoh16(x)
               ^
/usr/include/sys/endian.h:77:9: note: previous definition is here
#define be16toh(x)      bswap16((x))
        ^
In file included from /wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c:18:
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/portable_endian.h:53:10: warning: 'le16toh' macro redefined [-Wmacro-redefined]
#       define le16toh(x) letoh16(x)
               ^
/usr/include/sys/endian.h:80:9: note: previous definition is here
#define le16toh(x)      ((uint16_t)(x))
        ^
In file included from /wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c:18:
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/portable_endian.h:55:10: warning: 'be32toh' macro redefined [-Wmacro-redefined]
#       define be32toh(x) betoh32(x)
               ^
/usr/include/sys/endian.h:78:9: note: previous definition is here
#define be32toh(x)      bswap32((x))
        ^
In file included from /wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c:18:
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/portable_endian.h:56:10: warning: 'le32toh' macro redefined [-Wmacro-redefined]
#       define le32toh(x) letoh32(x)
               ^
/usr/include/sys/endian.h:81:9: note: previous definition is here
#define le32toh(x)      ((uint32_t)(x))
        ^
In file included from /wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c:18:
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/portable_endian.h:58:10: warning: 'be64toh' macro redefined [-Wmacro-redefined]
#       define be64toh(x) betoh64(x)
               ^
/usr/include/sys/endian.h:79:9: note: previous definition is here
#define be64toh(x)      bswap64((x))
        ^
In file included from /wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c:18:
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/portable_endian.h:59:10: warning: 'le64toh' macro redefined [-Wmacro-redefined]
#       define le64toh(x) letoh64(x)
               ^
/usr/include/sys/endian.h:82:9: note: previous definition is here
#define le64toh(x)      ((uint64_t)(x))
        ^
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/reader.c:183:11: warning: implicit declaration of function 'letoh64' is invalid in C99 [-Wimplicit-function-declaration]
    u.i = le64toh(*p2++);
          ^
/wrkdirs/usr/ports/audio/libmysofa/work/libmysofa-1.3.2/src/hrtf/portable_endian.h:59:21: note: expanded from macro 'le64toh'
#       define le64toh(x) letoh64(x)
                          ^
7 warnings generated.